### PR TITLE
Prevent `wrenGarbageCollect` to reenter.

### DIFF
--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -58,6 +58,9 @@ struct WrenVM
 
   // Memory management data:
 
+  // The lock that prevent garbage collection to re-enter.
+  bool lockGC;
+
   // The number of bytes that are known to be currently allocated. Includes all
   // memory that was proven live after the last GC, as well as any new bytes
   // that were allocated since then. Does *not* include bytes for objects that

--- a/test/api/foreign_class.c
+++ b/test/api/foreign_class.c
@@ -30,6 +30,16 @@ static void counterValue(WrenVM* vm)
   wrenSetSlotDouble(vm, 0, value);
 }
 
+static void rogueAllocate(WrenVM* vm)
+{
+  *(WrenVM**)wrenSetSlotNewForeign(vm, 0, 0, sizeof(WrenVM**)) = vm;
+}
+
+static void rogueFinalize(void* data)
+{
+  wrenCollectGarbage(*(WrenVM**)data);
+}
+
 static void pointAllocate(WrenVM* vm)
 {
   double* coordinates = (double*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(double[3]));
@@ -106,6 +116,13 @@ void foreignClassBindClass(
   if (strcmp(className, "Counter") == 0)
   {
     methods->allocate = counterAllocate;
+    return;
+  }
+
+  if (strcmp(className, "Rogue") == 0)
+  {
+    methods->allocate = rogueAllocate;
+    methods->finalize = rogueFinalize;
     return;
   }
 

--- a/test/api/foreign_class.wren
+++ b/test/api/foreign_class.wren
@@ -16,6 +16,14 @@ System.print(counter.value) // expect: 3.1
 counter.increment(1.2)
 System.print(counter.value) // expect: 4.3
 
+// Class that calls wrenCollectGarbage at destruction
+foreign class Rogue {
+  construct new() { }
+}
+
+Rogue.new()
+System.gc()
+
 // Foreign classes can inherit a class as long as it has no fields.
 class PointBase {
   inherited() {


### PR DESCRIPTION
In some scenarios (like issue #1063), it is possible that the function reenter. Disable that using a locking mecanism.