### PR TITLE
Wren: Add transform and iterate optionnal parameter to for loops

### DIFF
--- a/doc/site/control-flow.markdown
+++ b/doc/site/control-flow.markdown
@@ -163,6 +163,34 @@ A `for` loop has three components:
 3. A *body*. This is a curly block or a single statement. It gets executed once
    for each iteration of the loop.
 
+## Advanced for statements
+
+For statements can take a optionnal callable arguments to allow to customize
+the iterations. It looks like this:
+
+<pre class="snippet">
+var double = Fn.new {|iter, seq| seq.iteratorValue(iter) * 2 }
+var tracingIterate = Fn.new {|iter, seq|
+  iter = seq.iterate(iter)
+  System.print(seq.iteratorValue(iter))
+  return iter
+}
+
+for (i in 0..5, double) {
+  System.print(i)
+}
+</pre>
+
+The order of arguments is there allow to short circuiting if the
+*sequence expression* is not required to compute the value:
+
+<pre class="snippet">
+var double = Fn.new {|value| value  * 2 }
+for (i in 0..5, double) {
+  System.print(i)
+}
+</pre>
+
 ## Break statements
 
 Sometimes, right in the middle of a loop body, you decide you want to bail out

--- a/test/language/for/with_optional_iterate.wren
+++ b/test/language/for/with_optional_iterate.wren
@@ -1,0 +1,24 @@
+
+var tracingIterate = Fn.new {|iter, seq|
+  iter = seq.iterate(iter)
+  System.print(seq.iteratorValue(iter))
+  return iter
+}
+
+for (i in 0..5, , tracingIterate) {
+  System.print(i)
+}
+
+// expect: 0
+// expect: 0
+// expect: 1
+// expect: 1
+// expect: 2
+// expect: 2
+// expect: 3
+// expect: 3
+// expect: 4
+// expect: 4
+// expect: 5
+// expect: 5
+// expect: false

--- a/test/language/for/with_optional_transform.wren
+++ b/test/language/for/with_optional_transform.wren
@@ -1,0 +1,13 @@
+
+var double = Fn.new {|num| num * 2 }
+
+for (i in 0..5, double) {
+  System.print(i)
+}
+
+// expect: 0
+// expect: 2
+// expect: 4
+// expect: 6
+// expect: 8
+// expect: 10

--- a/test/language/for/with_optional_transform_and_iterate.wren
+++ b/test/language/for/with_optional_transform_and_iterate.wren
@@ -1,0 +1,25 @@
+
+var double = Fn.new {|num| num * 2 }
+var tracingIterate = Fn.new {|iter, seq|
+  iter = seq.iterate(iter)
+  System.print(seq.iteratorValue(iter))
+  return iter
+}
+
+for (i in 0..5, double, tracingIterate) {
+  System.print(i)
+}
+
+// expect: 0
+// expect: 0
+// expect: 1
+// expect: 2
+// expect: 2
+// expect: 4
+// expect: 3
+// expect: 6
+// expect: 4
+// expect: 8
+// expect: 5
+// expect: 10
+// expect: false

--- a/test/language/for/without_optional_transform.wren
+++ b/test/language/for/without_optional_transform.wren
@@ -1,0 +1,11 @@
+
+for (i in 0..5, ) {
+  System.print(i)
+}
+
+// expect: 0
+// expect: 1
+// expect: 2
+// expect: 3
+// expect: 4
+// expect: 5

--- a/test/language/for/without_optional_transform_and_iterate.wren
+++ b/test/language/for/without_optional_transform_and_iterate.wren
@@ -1,0 +1,11 @@
+
+for (i in 0..5, , ) {
+  System.print(i)
+}
+
+// expect: 0
+// expect: 1
+// expect: 2
+// expect: 3
+// expect: 4
+// expect: 5


### PR DESCRIPTION
Allow to pass optionnal parameters to for loops to allow to customize how the `for` statement extract increment the `iterator` and extract its value.