### PR TITLE
Fix null convertion in `Num::fromString` (#1131)

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -618,10 +618,13 @@ DEF_PRIMITIVE(num_fromString)
   char* end;
   double number = strtod(string->value, &end);
 
+  if (errno == ERANGE) RETURN_ERROR("Number literal is too large.");
+
+  // Check for no conversion.
+  if (number == 0.0 && string->value == end) RETURN_NULL;
+
   // Skip past any trailing whitespace.
   while (*end != '\0' && isspace((unsigned char)*end)) end++;
-
-  if (errno == ERANGE) RETURN_ERROR("Number literal is too large.");
 
   // We must have consumed the entire string. Otherwise, it contains non-number
   // characters and we can't parse it.

--- a/test/core/number/from_string.wren
+++ b/test/core/number/from_string.wren
@@ -8,6 +8,7 @@ System.print(Num.fromString(" 12 ") == 12) // expect: true
 // Test some non-number literals and ensure they return null.
 System.print(Num.fromString("test1") == null) // expect: true
 System.print(Num.fromString("") == null) // expect: true
+System.print(Num.fromString(" ") == null) // expect: true
 System.print(Num.fromString("prefix1.2") == null) // expect: true
 System.print(Num.fromString("1.2suffix") == null) // expect: true
 


### PR DESCRIPTION
When `strtod` returns `0.0`, no conversion could have happened. Handle the error case correctly.