### PR TITLE
wren/core: Make `Num` logical shift operand not rely on C undefined b…

### DIFF
--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -193,6 +193,15 @@ It is a runtime error if `denominator` is not a number.
 Compares this and `other`, returning `true` or `false` based on how the numbers
 are ordered. It is a runtime error if `other` is not a number.
 
+### **&lt;&lt;**(rhs), **&gt;&gt;**(rhs), **bitwiseShift**(rhs) operators
+
+Performs *bitwise* logical shift on the number. The number is first converted
+to a 32-bit unsigned value, which will truncate any floating point value. The
+bits of the result of that are then shifted, yielding the result.
+
+It is a runtime error if `other` is not a positive integer, unless using
+`bitwiseShift(rhs)` which accept any integer allowing left/right shifting.
+
 ### **~** operator
 
 Performs *bitwise* negation on the number. The number is first converted to a

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -654,17 +654,37 @@ DEF_NUM_INFIX(gte,      >=, BOOL)
 #define DEF_NUM_BITWISE(name, op)                                              \
     DEF_PRIMITIVE(num_bitwise##name)                                           \
     {                                                                          \
-      if (!validateNum(vm, args[1], "Right operand")) return false;            \
+      if (!validateInt(vm, args[0], "Left operand") ||                         \
+          !validateInt(vm, args[1], "Right operand")) return false;            \
       uint32_t left = (uint32_t)AS_NUM(args[0]);                               \
       uint32_t right = (uint32_t)AS_NUM(args[1]);                              \
       RETURN_NUM(left op right);                                               \
     }
 
+#define DEF_NUM_BITWISE_FN(name, fn)                                           \
+    DEF_PRIMITIVE(num_bitwise##name)                                           \
+    {                                                                          \
+      if (!validateInt(vm, args[0], "Left operand") ||                         \
+          !validateInt(vm, args[1], "Right operand")) return false;            \
+      uint32_t left = (uint32_t)AS_NUM(args[0]);                               \
+      uint32_t right = (uint32_t)AS_NUM(args[1]);                              \
+      RETURN_NUM(fn(left, right));                                             \
+    }
+
 DEF_NUM_BITWISE(And,        &)
 DEF_NUM_BITWISE(Or,         |)
 DEF_NUM_BITWISE(Xor,        ^)
-DEF_NUM_BITWISE(LeftShift,  <<)
-DEF_NUM_BITWISE(RightShift, >>)
+DEF_NUM_BITWISE_FN(LeftShift,  wrenBitwiseLeftShift_u32)
+DEF_NUM_BITWISE_FN(RightShift, wrenBitwiseRightShift_u32)
+
+DEF_PRIMITIVE(num_bitwiseShift)
+{
+  if (!validateInt(vm, args[0], "Left operand") ||
+      !validateInt(vm, args[1], "Right operand")) return false;
+  uint32_t left = (uint32_t)AS_NUM(args[0]);
+  int32_t right = (int32_t)AS_NUM(args[1]);
+  RETURN_NUM(wrenBitwiseShift_u32(left, right));
+}
 
 // Defines a primitive method on Num that returns the result of [fn].
 #define DEF_NUM_FN(name, fn)                                                   \
@@ -1341,6 +1361,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->numClass, "^(_)", num_bitwiseXor);
   PRIMITIVE(vm->numClass, "<<(_)", num_bitwiseLeftShift);
   PRIMITIVE(vm->numClass, ">>(_)", num_bitwiseRightShift);
+  PRIMITIVE(vm->numClass, "bitwiseShift(_)", num_bitwiseShift);
   PRIMITIVE(vm->numClass, "abs", num_abs);
   PRIMITIVE(vm->numClass, "acos", num_acos);
   PRIMITIVE(vm->numClass, "asin", num_asin);

--- a/src/vm/wren_math.h
+++ b/src/vm/wren_math.h
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 // A union to let us reinterpret a double as raw bits and back.
 typedef union
@@ -29,6 +30,21 @@ static inline uint64_t wrenDoubleToBits(double num)
   WrenDoubleBits data;
   data.num = num;
   return data.bits64;
+}
+
+static inline uint32_t wrenBitwiseLeftShift_u32(uint32_t lhs, size_t rhs)
+{
+  return rhs < 32 ? lhs << rhs : 0;
+}
+
+static inline uint32_t wrenBitwiseRightShift_u32(uint32_t lhs, size_t rhs)
+{
+  return rhs < 32 ? lhs >> rhs : 0;
+}
+
+static inline uint32_t wrenBitwiseShift_u32(uint32_t lhs, ssize_t rhs)
+{
+  return rhs < 0 ? wrenBitwiseLeftShift_u32(lhs, -rhs) : wrenBitwiseRightShift_u32(lhs, rhs);
 }
 
 #endif

--- a/test/core/number/bitwise_lsh.wren
+++ b/test/core/number/bitwise_lsh.wren
@@ -6,7 +6,8 @@ System.print(0xaaaaaaaa << 1) // expect: 1431655764
 System.print(0xf0f0f0f0 << 1) // expect: 3789677024
 
 // Max u32 value.
-System.print(0xffffffff << 0) // expect: 4294967295
+System.print(0xffffffff << 1) // expect: 4294967294
+System.print(0xffffffff << 32) // expect: 0
 
 // TODO: Negative numbers.
 // TODO: Floating-point numbers.

--- a/test/core/number/bitwise_rsh.wren
+++ b/test/core/number/bitwise_rsh.wren
@@ -7,6 +7,7 @@ System.print(0xf0f0f0f0 >> 1) // expect: 2021161080
 
 // Max u32 value.
 System.print(0xffffffff >> 1) // expect: 2147483647
+System.print(0xffffffff >> 32) // expect: 0
 
 // TODO: Negative numbers.
 // TODO: Floating-point numbers.

--- a/test/core/number/bitwise_shift.wren
+++ b/test/core/number/bitwise_shift.wren
@@ -1,0 +1,23 @@
+System.print(0.bitwiseShift(0)) // expect: 0
+System.print(1.bitwiseShift(0)) // expect: 1
+
+System.print(0.bitwiseShift(1)) // expect: 0
+System.print(1.bitwiseShift(1)) // expect: 0
+System.print(0xaaaaaaaa.bitwiseShift(1)) // expect: 1431655765
+System.print(0xf0f0f0f0.bitwiseShift(1)) // expect: 2021161080
+
+// Max u32 value.
+System.print(0xffffffff.bitwiseShift(1)) // expect: 2147483647
+System.print(0xffffffff.bitwiseShift(32)) // expect: 0
+
+System.print(0.bitwiseShift(-1)) // expect: 0
+System.print(1.bitwiseShift(-1)) // expect: 2
+System.print(0xaaaaaaaa.bitwiseShift(-1)) // expect: 1431655764
+System.print(0xf0f0f0f0.bitwiseShift(-1)) // expect: 3789677024
+
+// Max u32 value.
+System.print(0xffffffff.bitwiseShift(-1)) // expect: 4294967294
+System.print(0xffffffff.bitwiseShift(-32)) // expect: 0
+
+// TODO: Floating-point numbers.
+// TODO: Numbers that don't fit in u32.

--- a/test/core/number/bitwise_shift_operand_not_num.wren
+++ b/test/core/number/bitwise_shift_operand_not_num.wren
@@ -1,0 +1,1 @@
+1.bitwiseShift(false) // expect runtime error: Right operand must be a number.


### PR DESCRIPTION
…ehaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `bitwiseShift(rhs)` operator for performing logical shifts on numbers.
  - Added support for bitwise left and right shift operations on integers.

- **Documentation**
  - Updated documentation to clarify bitwise shift behavior with floating-point values and integers.

- **Tests**
  - Added new test cases for bitwise shift operations, including edge cases and error handling for non-numeric operands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->