### PR TITLE
Optimize some `Sequence` methods on `Range` and `List`

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -292,10 +292,31 @@ DEF_PRIMITIVE(fn_toString)
   RETURN_VAL(CONST_STRING(vm, "<fn>"));
 }
 
+static double calculateRangeCount(ObjRange* range)
+{
+  // Credit: Ruby MRI (https://github.com/ruby/ruby/blob/b2030d4dae3142e3fe6ad79ac1202de5a9f34a5a/numeric.c#L2536-L2563)
+
+  double n = fabs(range->to - range->from);
+  double err = (fabs(range->from) + fabs(range->to) + n) * DBL_EPSILON;
+  if (err > 0.5) err = 0.5;
+  if (range->isInclusive)
+  {
+    if (n < 0) return 0;
+    n = floor(n + err);
+  }
+  else
+  {
+    if (n <= 0) return 0;
+    n = n < 1 ? 0 : floor(n - err);
+  }
+  
+  return n + 1;
+}
+
 // Creates a new list of size args[1], with all elements initialized to args[2].
 DEF_PRIMITIVE(list_filled)
 {
-  if (!validateInt(vm, args[1], "Size")) return false;  
+  if (!validateInt(vm, args[1], "Size")) return false;
   if (AS_NUM(args[1]) < 0) RETURN_ERROR("Size cannot be negative.");
   
   uint32_t size = (uint32_t)AS_NUM(args[1]);
@@ -307,6 +328,15 @@ DEF_PRIMITIVE(list_filled)
   }
   
   RETURN_OBJ(list);
+}
+
+DEF_PRIMITIVE(list_toList)
+{
+  ObjList* list = AS_LIST(args[0]);
+  ObjList* result = wrenNewList(vm, list->elements.count);
+  memcpy(result->elements.data, list->elements.data,
+         list->elements.count * sizeof(Value));
+  RETURN_OBJ(result);
 }
 
 DEF_PRIMITIVE(list_new)
@@ -952,6 +982,166 @@ DEF_PRIMITIVE(range_toString)
   RETURN_VAL(result);
 }
 
+DEF_PRIMITIVE(range_count)
+{
+  RETURN_NUM(calculateRangeCount(AS_RANGE(args[0])));
+}
+
+DEF_PRIMITIVE(range_contains)
+{
+  if (!IS_NUM(args[1])) RETURN_FALSE;
+
+  ObjRange* range = AS_RANGE(args[0]);
+  double element = AS_NUM(args[1]);
+
+  double differenceFromFrom = element - range->from;
+  bool isDerivedFromFrom = floor(differenceFromFrom) == differenceFromFrom;
+  bool isInsideRange;
+  if (range->from < range->to)
+  {
+    if (range->isInclusive)
+    {
+      isInsideRange = range->from <= element && element <= range->to;
+    }
+    else
+    {
+      isInsideRange = range->from <= element && element < range->to;
+    }
+  }
+  else
+  {
+    if (range->isInclusive)
+    {
+      isInsideRange = range->to <= element && element <= range->from;
+    }
+    else
+    {
+      isInsideRange = range->to < element && element <= range->from;
+    }
+  }
+  RETURN_BOOL(isDerivedFromFrom && isInsideRange);
+}
+
+DEF_PRIMITIVE(range_skip)
+{
+  if (!validateInt(vm, args[1], "Count")) return false;
+  double count = AS_NUM(args[1]);
+  if (count < 0) RETURN_ERROR("Count must be a non-negative integer.");
+
+  ObjRange* range = AS_RANGE(args[0]);
+  if (range->from < range->to)
+  {
+    double newFrom = range->from + count;
+    if (newFrom > range->to)
+    {
+      // Return an empty range
+      RETURN_VAL(wrenNewRange(vm, range->to, range->to, false));
+    }
+    else
+    {
+      RETURN_VAL(wrenNewRange(vm, newFrom, range->to, range->isInclusive));
+    }
+  }
+  else
+  {
+    double newFrom = range->from - count;
+    if (newFrom < range->to)
+    {
+      // Return an empty range
+      RETURN_VAL(wrenNewRange(vm, range->to, range->to, false));
+    }
+    else
+    {
+      RETURN_VAL(wrenNewRange(vm, newFrom, range->to, range->isInclusive));
+    }
+  }
+}
+
+DEF_PRIMITIVE(range_take)
+{
+  if (!validateInt(vm, args[1], "Count")) return false;
+  double count = AS_NUM(args[1]);
+  if (count < 0) RETURN_ERROR("Count must be a non-negative integer.");
+
+  ObjRange* range = AS_RANGE(args[0]);
+  if (range->from < range->to)
+  {
+    double newTo = range->from + count;
+    if (newTo >= range->to)
+    {
+      RETURN_VAL(args[0]);
+    }
+    else
+    {
+      RETURN_VAL(wrenNewRange(vm, range->from, newTo, false));
+    }
+  }
+  else
+  {
+    double newTo = range->from - count;
+    if (newTo <= range->to)
+    {
+      RETURN_VAL(args[0]);
+    }
+    else
+    {
+      RETURN_VAL(wrenNewRange(vm, range->from, newTo, false));
+    }
+  }
+}
+
+DEF_PRIMITIVE(range_toList)
+{
+  ObjRange* range = AS_RANGE(args[0]);
+  uint32_t count = (uint32_t)calculateRangeCount(range);
+  ObjList* result = wrenNewList(vm, count);
+
+  if (range->from < range->to)
+  {
+    if (range->isInclusive)
+    {
+      uint32_t i = 0;
+      for (double value = range->from; value <= range->to; value++)
+      {
+          result->elements.data[i] = NUM_VAL(value);
+          i++;
+      }
+    }
+    else
+    {
+      uint32_t i = 0;
+      for (double value = range->from; value < range->to; value++)
+      {
+          result->elements.data[i] = NUM_VAL(value);
+          i++;
+      }
+    }
+  }
+  else
+  {
+    if (range->isInclusive)
+    {
+      uint32_t i = 0;
+      for (double value = range->from; value >= range->to; value--)
+      {
+          result->elements.data[i] = NUM_VAL(value);
+          i++;
+      }
+    }
+    else
+    {
+      uint32_t i = 0;
+      for (double value = range->from; value > range->to; value--)
+      {
+          result->elements.data[i] = NUM_VAL(value);
+          i++;
+      }
+    }
+  }
+
+  RETURN_OBJ(result);
+}
+
 DEF_PRIMITIVE(string_fromCodePoint)
 {
   if (!validateInt(vm, args[1], "Code point")) return false;
@@ -1411,6 +1601,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->listClass, "removeAt(_)", list_removeAt);
   PRIMITIVE(vm->listClass, "indexOf(_)", list_indexOf);
   PRIMITIVE(vm->listClass, "swap(_,_)", list_swap);
+  PRIMITIVE(vm->listClass, "toList", list_toList);
 
   vm->mapClass = AS_CLASS(wrenFindVariable(vm, coreModule, "Map"));
   PRIMITIVE(vm->mapClass->obj.classObj, "new()", map_new);
@@ -1434,6 +1625,11 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->rangeClass, "iterate(_)", range_iterate);
   PRIMITIVE(vm->rangeClass, "iteratorValue(_)", range_iteratorValue);
   PRIMITIVE(vm->rangeClass, "toString", range_toString);
+  PRIMITIVE(vm->rangeClass, "count", range_count);
+  PRIMITIVE(vm->rangeClass, "contains(_)", range_contains);
+  PRIMITIVE(vm->rangeClass, "skip(_)", range_skip);
+  PRIMITIVE(vm->rangeClass, "take(_)", range_take);
+  PRIMITIVE(vm->rangeClass, "toList", range_toList);
 
   ObjClass* systemClass = AS_CLASS(wrenFindVariable(vm, coreModule, "System"));
   PRIMITIVE(systemClass->obj.classObj, "clock", system_clock);

--- a/test/core/range/contains.wren
+++ b/test/core/range/contains.wren
@@ -21,3 +21,7 @@ System.print((5...2).contains(1)) // expect: false
 System.print((5...2).contains(2)) // expect: false
 System.print((5...2).contains(5)) // expect: true
 System.print((5...2).contains(6)) // expect: false
+
+// Not numbers
+System.print((0..0).contains("")) // expect: false
+System.print((0..0).contains(null)) // expect: false

--- a/test/core/range/count.wren
+++ b/test/core/range/count.wren
@@ -1,0 +1,34 @@
+// Ordered range.
+System.print((2..5).count) // expect: 4
+System.print((3..3).count) // expect: 1
+System.print((0..3).count) // expect: 4
+System.print((-5..3).count) // expect: 9
+System.print((-5..-2).count) // expect: 4
+System.print((0.1..10).count) // expect: 10
+System.print((0.1..10.1).count) // expect: 11
+
+// Backwards range.
+System.print((5..2).count) // expect: 4
+System.print((3..0).count) // expect: 4
+System.print((3..-5).count) // expect: 9
+System.print((-2..-5).count) // expect: 4
+System.print((10..0.1).count) // expect: 10
+// Due to the oddnesses floating point arithmetic, previously `count` yieled 10 on the next line, which is the correct result. I don't know how to fix that.
+System.print((10.1..0.1).count) // expect: 11
+
+// Exclusive ordered range.
+System.print((2...5).count) // expect: 3
+System.print((3...3).count) // expect: 0
+System.print((0...3).count) // expect: 3
+System.print((-5...3).count) // expect: 8
+System.print((-5...-2).count) // expect: 3
+System.print((0.1...10).count) // expect: 10
+System.print((0.1...10.1).count) // expect: 10
+
+// Exclusive backwards range.
+System.print((5...2).count) // expect: 3
+System.print((3...0).count) // expect: 3
+System.print((3...-5).count) // expect: 8
+System.print((-2...-5).count) // expect: 3
+System.print((10...0.1).count) // expect: 10
+System.print((10.1...0.1).count) // expect: 10

--- a/test/core/range/skip.wren
+++ b/test/core/range/skip.wren
@@ -1,0 +1,17 @@
+// Ordered range.
+System.print((2..5).skip(1).toList) // expect: [3, 4, 5]
+System.print((3..3).skip(0).toList) // expect: [3]
+System.print((0..3).skip(8).toList) // expect: []
+System.print((-5..3).skip(1).toList) // expect: [-4, -3, -2, -1, 0, 1, 2, 3]
+System.print((-5..-2).skip(9).toList) // expect: []
+System.print((0.1..10).skip(4).toList) // expect: [4.1, 5.1, 6.1, 7.1, 8.1, 9.1]
+System.print((0.1..5.1).skip(100).toList) // expect: []
+
+// Backwards range.
+System.print((5..2).skip(1).toList) // expect: [4, 3, 2]
+
+// Exclusive ordered range.
+System.print((2...5).skip(2).toList) // expect: [4]
+
+// Exclusive backwards range.
+System.print((5...2).skip(2).toList) // expect: [3]

--- a/test/core/range/skip_count_negative_integer.wren
+++ b/test/core/range/skip_count_negative_integer.wren
@@ -1,0 +1,1 @@
+(1...2).skip(-1) // expect runtime error: Count must be a non-negative integer.

--- a/test/core/range/skip_count_non_integer.wren
+++ b/test/core/range/skip_count_non_integer.wren
@@ -1,0 +1,1 @@
+(1...2).skip(1.9) // expect runtime error: Count must be an integer.

--- a/test/core/range/skip_count_non_number.wren
+++ b/test/core/range/skip_count_non_number.wren
@@ -1,0 +1,1 @@
+(1...2).skip(null) // expect runtime error: Count must be a number.

--- a/test/core/range/take.wren
+++ b/test/core/range/take.wren
@@ -1,0 +1,17 @@
+// Ordered range.
+System.print((2..5).take(0).toList) // expect: []
+System.print((3..3).take(1).toList) // expect: [3]
+System.print((0..3).take(8).toList) // expect: [0, 1, 2, 3]
+System.print((-5..3).take(1).toList) // expect: [-5]
+System.print((-5..-2).take(0).toList) // expect: []
+System.print((0.1..10).take(4).toList) // expect: [0.1, 1.1, 2.1, 3.1]
+System.print((0.1..5.1).take(100).toList) // expect: [0.1, 1.1, 2.1, 3.1, 4.1, 5.1]
+
+// Backwards range.
+System.print((5..2).take(1).toList) // expect: [5]
+
+// Exclusive ordered range.
+System.print((2...5).take(3).toList) // expect: [2, 3, 4]
+
+// Exclusive backwards range.
+System.print((5...2).take(3).toList) // expect: [5, 4, 3]

--- a/test/core/range/take_count_negative_integer.wren
+++ b/test/core/range/take_count_negative_integer.wren
@@ -1,0 +1,1 @@
+(1...2).take(-1) // expect runtime error: Count must be a non-negative integer.

--- a/test/core/range/take_count_non_integer.wren
+++ b/test/core/range/take_count_non_integer.wren
@@ -1,0 +1,1 @@
+(1...2).take(1.9) // expect runtime error: Count must be an integer.

--- a/test/core/range/take_count_non_number.wren
+++ b/test/core/range/take_count_non_number.wren
@@ -1,0 +1,1 @@
+(1...2).take(null) // expect runtime error: Count must be a number.

--- a/test/core/range/toList.wren
+++ b/test/core/range/toList.wren
@@ -1,0 +1,17 @@
+// Ordered range.
+System.print((2..5).toList) // expect: [2, 3, 4, 5]
+System.print((3..3).toList) // expect: [3]
+System.print((0..3).toList) // expect: [0, 1, 2, 3]
+System.print((-5..3).toList) // expect: [-5, -4, -3, -2, -1, 0, 1, 2, 3]
+System.print((-5..-2).toList) // expect: [-5, -4, -3, -2]
+System.print((0.1..5).toList) // expect: [0.1, 1.1, 2.1, 3.1, 4.1]
+System.print((0.1..5.1).toList) // expect: [0.1, 1.1, 2.1, 3.1, 4.1, 5.1]
+
+// Backwards range.
+System.print((5..2).toList) // expect: [5, 4, 3, 2]
+
+// Exclusive ordered range.
+System.print((2...5).toList) // expect: [2, 3, 4]
+
+// Exclusive backwards range.
+System.print((5...2).toList) // expect: [5, 4, 3]


### PR DESCRIPTION
The methods that got optimized:
 - `toList` in both `Range` and `List`. They both preallocate enough space instead of keeping adding elements. On `List` we also use `memcpy()` to effectively copy the list.
 - `count` and `contains(_)` on `Range`. They both calculates the value now instead of iterating over the range to determine it.
 - `take(_)` and `skip(_)` on `Range`. They both return a new precalculated range instead of a dedicated sequence (`TakeSequence` and `SkipSequence`, respectively, in wren_core.wren). This is not a major gain, but it allows the previous optimized method to be used on the result instead of their slower `Sequence` counterparts.

All methods were implemented in C rather than Wren.