### PR TITLE
Do not lookup for allocator/finalizer every time we allocate/dealloca…

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -21,6 +21,11 @@
   #include <stdio.h>
 #endif
 
+typedef enum {
+  PREDEF_ALLOCATE = 0,
+  PREDEF_FINALIZE = 1
+} PredefinedSymbol;
+
 // The behavior of realloc() when the size is 0 is implementation defined. It
 // may return a non-NULL pointer which must not be dereferenced but nevertheless
 // should be freed. To prevent that, we avoid calling realloc() with a zero
@@ -34,6 +39,18 @@ static void* defaultReallocate(void* ptr, size_t newSize, void* _)
   }
 
   return realloc(ptr, newSize);
+}
+
+static inline void ensurePredefinedSymbol(WrenVM* vm,
+    const char* name, PredefinedSymbol expectedSymbol) {
+  int symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, name, strlen(name));
+  ASSERT(symbol == expectedSymbol, "Definition of predefined symbols went wrong.");
+}
+
+// This function ensures that the special method symbols are there.
+static void ensurePredefinedSymbols(WrenVM* vm) {
+  ensurePredefinedSymbol(vm, "<allocate>", PREDEF_ALLOCATE);
+  ensurePredefinedSymbol(vm, "<finalize>", PREDEF_FINALIZE);
 }
 
 void wrenInitConfiguration(WrenConfiguration* config)
@@ -81,6 +98,7 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   vm->nextGC = vm->config.initialHeapSize;
 
   wrenSymbolTableInit(&vm->methodNames);
+  ensurePredefinedSymbols(vm);
 
   vm->modules = wrenNewMap(vm);
   wrenInitializeCore(vm);
@@ -579,22 +597,16 @@ static void bindForeignClass(WrenVM* vm, ObjClass* classObj, ObjModule* module)
   Method method;
   method.type = METHOD_FOREIGN;
 
-  // Add the symbol even if there is no allocator so we can ensure that the
-  // symbol itself is always in the symbol table.
-  int symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, "<allocate>", 10);
   if (methods.allocate != NULL)
   {
     method.as.foreign = methods.allocate;
-    wrenBindMethod(vm, classObj, symbol, method);
+    wrenBindMethod(vm, classObj, PREDEF_ALLOCATE, method);
   }
   
-  // Add the symbol even if there is no finalizer so we can ensure that the
-  // symbol itself is always in the symbol table.
-  symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, "<finalize>", 10);
   if (methods.finalize != NULL)
   {
     method.as.foreign = (WrenForeignMethodFn)methods.finalize;
-    wrenBindMethod(vm, classObj, symbol, method);
+    wrenBindMethod(vm, classObj, PREDEF_FINALIZE, method);
   }
 }
 
@@ -630,12 +642,7 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
   ObjClass* classObj = AS_CLASS(stack[0]);
   ASSERT(classObj->numFields == -1, "Class must be a foreign class.");
 
-  // TODO: Don't look up every time.
-  int symbol = wrenSymbolTableFind(&vm->methodNames, "<allocate>", 10);
-  ASSERT(symbol != -1, "Should have defined <allocate> symbol.");
-
-  ASSERT(classObj->methods.count > symbol, "Class should have allocator.");
-  Method* method = &classObj->methods.data[symbol];
+  Method* method = &classObj->methods.data[PREDEF_ALLOCATE];
   ASSERT(method->type == METHOD_FOREIGN, "Allocator should be foreign.");
 
   // Pass the constructor arguments to the allocator as well.
@@ -649,18 +656,9 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
 
 void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign)
 {
-  // TODO: Don't look up every time.
-  int symbol = wrenSymbolTableFind(&vm->methodNames, "<finalize>", 10);
-  ASSERT(symbol != -1, "Should have defined <finalize> symbol.");
-
-  // If there are no finalizers, don't finalize it.
-  if (symbol == -1) return;
-
   // If the class doesn't have a finalizer, bail out.
   ObjClass* classObj = foreign->obj.classObj;
-  if (symbol >= classObj->methods.count) return;
-
-  Method* method = &classObj->methods.data[symbol];
+  Method* method = &classObj->methods.data[PREDEF_FINALIZE];
   if (method->type == METHOD_NONE) return;
 
   ASSERT(method->type == METHOD_FOREIGN, "Finalizer should be foreign.");


### PR DESCRIPTION
…te a class

Lookup is expensive: it implies hash table lookup. Although an optimizing compiler can fold the hash of "<allocate>" and "<finalize>" (and thus avoid recomputing it every time), the process is still more expensive than we want, especially since that every foreign class _allocation_ (not just _declaration_) does that, and also GC for every foreign class, which may delay GC that in turn blocks code from executing, which can, for example, trigger a FPS dropping in a game.

The way we avoid it is by adding the "<allocate>" and "<finalize>" strings to the symbols table, before anything else. This way, due to the nature of the symbol table that increments each symbol by one, we can know what are the values of those symbols; and thus, when we need to access them, we just address at the known symbol.

This has the disadvantage of adding two entries to the methods table of each class, but considering that:

 1. We already have pretty high number of wasted entries, with direct proportion to the number of classes and methods (the more methods you have the more wasted entries you have per class, the more classes you have the more wasted entries you have in total).
 2. Each entry is just the size of two pointers (16 bytes on 64-bit systems, 8 bytes on 32 bit systems) include padding, and
 3. The speed we gain from that (again, for every allocation/deallocation of a foreign class),

I think this is a worthwhile trade-off.